### PR TITLE
fix: add types dir to publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   },
   "files": [
     "dist",
+    "types",
     "README.md"
   ]
 }


### PR DESCRIPTION
```bash
$ npm publish --dry-run                                                                                                                   git:(publish-types|) 
npm notice 
npm notice 📦  ts-junit@1.0.18
npm notice === Tarball Contents === 
npm notice 1.1kB  LICENSE                      
npm notice 22.5kB README.md                    
npm notice 3.3kB  dist/ast.js                  
npm notice 448B   dist/bin.js                  
npm notice 2.4kB  dist/context.js              
npm notice 4.3kB  dist/decrator.js             
npm notice 2.2kB  dist/index.js                
npm notice 77B    dist/iStrategy.js            
npm notice 1.2kB  dist/loadObject/flatten.js   
npm notice 3.1kB  dist/loadObject/require.js   
npm notice 5.3kB  dist/loadObject/scan.js      
npm notice 6.3kB  dist/parse.js                
npm notice 4.8kB  dist/utils.js                
npm notice 1.7kB  dist/uvuStrategy.js          
npm notice 5.4kB  dist/watch.js                
npm notice 1.7kB  package.json                 
npm notice 437B   types/ast.d.ts               
npm notice 31B    types/bin.d.ts               
npm notice 244B   types/context.d.ts           
npm notice 842B   types/decrator.d.ts          
npm notice 442B   types/index.d.ts             
npm notice 165B   types/iStrategy.d.ts         
npm notice 133B   types/loadObject/flatten.d.ts
npm notice 61B    types/loadObject/require.d.ts
npm notice 360B   types/loadObject/scan.d.ts   
npm notice 366B   types/parse.d.ts             
npm notice 412B   types/utils.d.ts             
npm notice 221B   types/uvuStrategy.d.ts       
npm notice 114B   types/watch.d.ts             
npm notice === Tarball Details === 
npm notice name:          ts-junit                                
npm notice version:       1.0.18                                  
npm notice filename:      ts-junit-1.0.18.tgz                     
npm notice package size:  15.8 kB                                 
npm notice unpacked size: 69.6 kB                                 
npm notice shasum:        888a0719e5c4f265009081328f62b9a75f278407
npm notice integrity:     sha512-lXskpiQwVhRLl[...]SfY3OXQP53Ihw==
npm notice total files:   29                                      
npm notice 
npm notice Publishing to https://registry.npmjs.org/ (dry-run)
+ ts-junit@1.0.18
```